### PR TITLE
Migrate API

### DIFF
--- a/API.md
+++ b/API.md
@@ -1,3 +1,29 @@
+
+### `migrate(style)`
+
+Migrate a Mapbox GL Style to the latest version.
+
+
+### Parameters
+
+| parameter | type   | description       |
+| --------- | ------ | ----------------- |
+| `style`   | object | a Mapbox GL Style |
+
+
+### Example
+
+```js
+var fs = require('fs');
+var migrate = require('mapbox-gl-style-lint').migrate;
+var style = fs.readFileSync('./style.json', 'utf8');
+fs.writeFileSync('./style.json', JSON.stringify(migrate(style)));
+```
+
+
+**Returns** `Object`, a migrated style
+
+
 ### `validate(str)`
 
 Validate a Mapbox GL Style given as a string of JSON. Returns an array
@@ -21,10 +47,11 @@ first.
 
 ```js
 var fs = require('fs');
-var validate = require('mapbox-gl-style-lint');
+var validate = require('mapbox-gl-style-lint').validate;
 var style = fs.readFileSync('./style.json', 'utf8');
 var errors = validate(style);
 ```
 
 
 **Returns** `Array.<Object>`, an array of error objects
+

--- a/bin/gl-style-format
+++ b/bin/gl-style-format
@@ -4,6 +4,6 @@
 
 var fs = require('fs'),
     argv = require('minimist')(process.argv.slice(2)),
-    format = require('../lib/format');
+    format = require('../').format;
 
 console.log(format(JSON.parse(fs.readFileSync(argv._[0]))));

--- a/bin/gl-style-migrate
+++ b/bin/gl-style-migrate
@@ -4,41 +4,7 @@
 
 var fs = require('fs'),
     argv = require('minimist')(process.argv.slice(2)),
-    format = require('../lib/format');
+    format = require('../').format,
+    migrate = require('../').migrate;
 
-var data = JSON.parse(fs.readFileSync(argv._[0]));
-
-var migrated = false;
-
-if (data.version === 2) {
-    data = require('../migrations/v3')(data);
-    migrated = true;
-}
-
-if (data.version === 3) {
-    data = require('../migrations/v4')(data);
-    data = require('../migrations/v4-bonus')(data);
-    migrated = true;
-}
-
-if (data.version === 4) {
-    data = require('../migrations/v5')(data);
-    migrated = true;
-}
-
-if (data.version === 5) {
-    data = require('../migrations/v6')(data);
-    migrated = true;
-}
-
-if (data.version === 6 || data.version === 7) {
-    data = require('../migrations/v7')(data);
-    migrated = true;
-}
-
-if (!migrated) {
-    console.warn('cannot migrate from', data.version);
-    process.exit(1);
-}
-
-console.log(format(data));
+console.log(format(migrate(JSON.parse(fs.readFileSync(argv._[0])))));

--- a/bin/gl-style-validate
+++ b/bin/gl-style-validate
@@ -5,7 +5,7 @@
 var argv = require('minimist')(process.argv.slice(2), {
         boolean: 'json'
     }),
-    validate = require('../lib/validate'),
+    validate = require('../').validate,
     rw = require('rw'),
     status = 0;
 

--- a/index.js
+++ b/index.js
@@ -1,0 +1,3 @@
+exports.format = require('./lib/format');
+exports.migrate = require('./lib/migrate');
+exports.validate = require('./lib/validate');

--- a/lib/migrate.js
+++ b/lib/migrate.js
@@ -1,0 +1,49 @@
+'use strict';
+
+/**
+ * Migrate a Mapbox GL Style to the latest version.
+ *
+ * @alias migrate
+ * @param {object} style a Mapbox GL Style
+ * @returns {Object} a migrated style
+ * @example
+ * var fs = require('fs');
+ * var migrate = require('mapbox-gl-style-lint').migrate;
+ * var style = fs.readFileSync('./style.json', 'utf8');
+ * fs.writeFileSync('./style.json', JSON.stringify(migrate(style)));
+ */
+module.exports = function(style) {
+    var migrated = false;
+
+    if (style.version === 2) {
+        style = require('../migrations/v3')(style);
+        migrated = true;
+    }
+
+    if (style.version === 3) {
+        style = require('../migrations/v4')(style);
+        style = require('../migrations/v4-bonus')(style);
+        migrated = true;
+    }
+
+    if (style.version === 4) {
+        style = require('../migrations/v5')(style);
+        migrated = true;
+    }
+
+    if (style.version === 5) {
+        style = require('../migrations/v6')(style);
+        migrated = true;
+    }
+
+    if (style.version === 6 || style.version === 7) {
+        style = require('../migrations/v7')(style);
+        migrated = true;
+    }
+
+    if (!migrated) {
+        throw new Error('cannot migrate from', style.version);
+    }
+
+    return style;
+};

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -20,7 +20,7 @@ var format = require('util').format;
  * @returns {Array<Object>} an array of error objects
  * @example
  * var fs = require('fs');
- * var validate = require('mapbox-gl-style-lint');
+ * var validate = require('mapbox-gl-style-lint').validate;
  * var style = fs.readFileSync('./style.json', 'utf8');
  * var errors = validate(style);
  */

--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "mapbox-gl-style-lint",
   "version": "7.0.0",
   "description": "migrate and validate mapbox gl style definitions",
-  "main": "lib/validate.js",
   "bin": {
     "gl-style-migrate": "bin/gl-style-migrate",
     "gl-style-validate": "bin/gl-style-validate",
@@ -10,7 +9,7 @@
   },
   "scripts": {
     "test": "jshint lib/*.js migrations/*.js && tape test/*.js test/migrations/*.js",
-    "doc": "dox -r < lib/validate.js | doxme",
+    "doc": "cat lib/*.js | dox --raw --skipSingleStar | doxme > API.md",
     "cov": "istanbul cover ./node_modules/.bin/tape test/*.js test/migrations/*.js && coveralls < ./coverage/lcov.info"
   },
   "repository": {

--- a/test/migrate.js
+++ b/test/migrate.js
@@ -1,0 +1,12 @@
+'use strict';
+
+var t = require('tape'),
+    spec = require('mapbox-gl-style-spec'),
+    migrate = require('../').migrate;
+
+t('migrates to latest version', function(t) {
+    var versions = Object.keys(spec),
+        latest = spec[versions[versions.length - 1]].$version;
+    t.deepEqual(migrate({version: 4, layers: []}).version, latest);
+    t.end();
+});

--- a/test/validate.js
+++ b/test/validate.js
@@ -5,7 +5,7 @@ var t = require('tape'),
     glob = require('glob'),
     fs = require('fs'),
     path = require('path'),
-    validate = require('../');
+    validate = require('../').validate;
 
 var UPDATE = !!process.env.UPDATE;
 


### PR DESCRIPTION
Need to make `migrate` npm-accessible for automated migrations in the styles API.
